### PR TITLE
Fix service monitor yaml

### DIFF
--- a/charts/openmetadata/templates/servicemonitor.yaml
+++ b/charts/openmetadata/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "OpenMetadata.selectorLabels" . | indent 6 }}
+      {{- include "OpenMetadata.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http-admin
       path: /prometheus


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
The current version gives the following error when enabling the service monitor:
```
Error: YAML parse error on openmetadata/charts/openmetadata/templates/servicemonitor.yaml: error converting YAML to JSON: yaml: line 16: mapping values are not allowed in this context
```
That happens because the following yaml is being generated:
```
spec:
  selector:
    matchLabels:      app.kubernetes.io/name: openmetadata
      app.kubernetes.io/instance: openmetadata
```
This should be fixed by using `nindent` instead of `indent`.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] My changes generate no new warnings.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
@akash-jain-10